### PR TITLE
Write the minecraft eula after installing minecraft.

### DIFF
--- a/site.pp
+++ b/site.pp
@@ -29,3 +29,9 @@ class { 'minecraft':
   autostart          => true,
   manage_java        => true,
 }
+
+file { "/opt/minecraft/eula.txt":
+  ensure => "present",
+  content => "eula=true",
+  require => Class["minecraft"],
+}


### PR DESCRIPTION
The problem here is that by default the minecraft puppet class does not
aggree to the EULA, so this adds a line to do that automatically.

r? @LukeusMaximus @JamesLaverack 
